### PR TITLE
Fix for undefined response values

### DIFF
--- a/src/SteamMarket.ts
+++ b/src/SteamMarket.ts
@@ -502,7 +502,7 @@ class SteamMarket {
       _data: response.data,
       success: response.data.success,
       lowestPrice: response.data.lowest_price,
-      volume: Number(response.data.volume.split(',').join('')),
+      volume: response.data.volume === undefined ? response.data.volume : Number(response.data.volume.split(',').join('')),
       medianPrice: response.data.median_price,
     }
   }

--- a/src/types/PriceOverview.ts
+++ b/src/types/PriceOverview.ts
@@ -4,6 +4,6 @@ export interface PriceOverview {
   _data: PriceOverviewResponse
   success: boolean
   lowestPrice: string
-  volume: number
-  medianPrice: string
+  volume?: number
+  medianPrice?: string
 }

--- a/src/types/PriceOverviewResponse.ts
+++ b/src/types/PriceOverviewResponse.ts
@@ -1,6 +1,6 @@
 export interface PriceOverviewResponse {
   success: boolean
   lowest_price: string
-  volume: string
-  median_price: string
+  volume?: string
+  median_price?: string
 }


### PR DESCRIPTION
A call to `https://steamcommunity.com/market/priceoverview/?appid=590830&country=AU&currency=21&market_hash_name=Black%20Modern%20Watch` returned `{"success":true,"lowest_price":"A$ 1.64"}` for me, consistently in all my browsers and in the js request.

This was causing errors when running as the `volume` was undefined and it was trying to be split. I have made the `volume` and `medianPrice` optional as well as added checks to not split the `volume` if it doesn't exist. 

For the time being I'm just using this fix locally but would be good to have it pushed to NPM.